### PR TITLE
Add libglib2.0-dev as a build dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libhal1-flash (0.2.0rc1+nmu1) unstable; urgency=low
+
+  * Add glib-dev as a build dependency
+
+ -- Ryan Nowakowski <tubaman@fattuba.com>  Fri, 16 Jan 2015 17:52:23 -0600
+
 libhal1-flash (0.2.0rc1) unstable; urgency=low
 
   * Initial Release.

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: libhal1-flash
 Priority: extra
 Maintainer: Christopher Horler <cshorler@googlemail.com>
-Build-Depends: debhelper (>= 8.0.0), dh-autoreconf, pkg-config, libdbus-1-dev
+Build-Depends: debhelper (>= 8.0.0), dh-autoreconf, pkg-config, libdbus-1-dev, libglib2.0-dev
 Standards-Version: 3.9.3
 Section: libs
 Homepage: https://github.com/cshorler/hal-flash


### PR DESCRIPTION
When trying to build on Debian Jessie, I got an ./configure error complaining about missing gio-2.0.  To get this to build, I needed to add libglib2.0-dev as a build dependency.