### PR TITLE
add libhal_device_get_property_bool for libeTPkcs11

### DIFF
--- a/src/libhal.c
+++ b/src/libhal.c
@@ -357,3 +357,9 @@ libhal_device_get_property_double (LibHalContext *ctx, const char *udi, const ch
     return -1.0f;
 }
 
+dbus_bool_t
+libhal_device_get_property_bool (LibHalContext *ctx, const char *udi, const char *key, DBusError *error)
+{
+    g_printerr("%s:%d: bool '%s' not handled\n", __FILE__, __LINE__, key);
+    return FALSE;
+}

--- a/src/libhal.h
+++ b/src/libhal.h
@@ -110,6 +110,12 @@ double libhal_device_get_property_double (LibHalContext *ctx,
 					  const char *key,
 					  DBusError *error);
 
+/* Get the value of a property of type bool. */
+dbus_bool_t libhal_device_get_property_bool (LibHalContext *ctx,
+					  const char *udi,
+					  const char *key,
+					  DBusError *error);
+
 /* Query a property type of a device. */
 LibHalPropertyType libhal_device_get_property_type (LibHalContext *ctx, 
 						    const char *udi,


### PR DESCRIPTION
The SafeNet Authentication Client PKCS#11 module (v8.x, for my Aladdin eToken) needs this function, though, as far as I can see, it doesn't actually query any properties.
