### PR TITLE
debian: remove a duplicated Section: field

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,6 @@ Homepage: https://github.com/cshorler/hal-flash
 #Vcs-Browser: http://git.debian.org/?p=collab-maint/libhal1-flash.git;a=summary
 
 Package: libhal1-flash
-Section: libs
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, udisks2
 Suggests: flashplugin-installer


### PR DESCRIPTION
It fixes I:binary-control-field-duplicates-source field "section" in
package libhal1-flash lintian warning:

N:
N:    In debian/control, this field for a binary package duplicates the value
N:    inherited from the source package paragraph. This doesn't hurt anything,
N:    but you may want to take advantage of the inheritance and set the value
N:    in only one place. It prevents missing duplicate places that need to be
N:    fixed if the value ever changes.
N:
