### PR TITLE
debian: fix email address

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -26,4 +26,4 @@ libhal1-flash (0.2.0rc1) unstable; urgency=low
 
   * Initial Release.
 
- -- Christopher Horler <chorler@debian>  Wed, 29 May 2013 20:38:36 +0100
+ -- Christopher Horler <cshorler@googlemail.com>  Wed, 29 May 2013 20:38:36 +0100


### PR DESCRIPTION
It fixes E:debian-changelog-file-contains-invalid-email-address lintian
warning:

N:
N:    The changelog file contains an invalid email address: the domain needs
N:    at least one dot. This looks like a mistake.
N:
