### PR TITLE
debian: fix mismatch between archive and source package name

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: libhal1-flash
+Source: hal-flash
 Priority: extra
 Maintainer: Christopher Horler <cshorler@googlemail.com>
 Build-Depends: debhelper (>= 9), dh-autoreconf, pkg-config, libdbus-1-dev, libglib2.0-dev


### PR DESCRIPTION
It fixes following the error:

  dpkg-source: error: source package has two conflicting values - libhal1-flash and hal-flash
  dpkg-buildpackage: error: dpkg-source -I -i --before-build hal-flash-0.3.3 gave error exit status 2
  debuild: fatal error at line 1376:
