### PR TITLE
debian: update standard version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libhal1-flash
 Priority: extra
 Maintainer: Christopher Horler <cshorler@googlemail.com>
 Build-Depends: debhelper (>= 9), dh-autoreconf, pkg-config, libdbus-1-dev, libglib2.0-dev
-Standards-Version: 3.9.6
+Standards-Version: 3.9.7
 Section: libs
 Homepage: https://github.com/cshorler/hal-flash
 #Vcs-Git: git://git.debian.org/collab-maint/libhal1-flash.git


### PR DESCRIPTION
It fixes W:out-of-date-standards-version lintian warning

W: hal-flash source: out-of-date-standards-version 3.9.6 (current is 3.9.7)
